### PR TITLE
Add archive notice to home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,6 +113,9 @@ jQuery.extend(Drupal.settings, { "basePath": "/", "googleanalytics": { "trackOut
 
       <div class="section">
 
+                  <div class="messages warning">
+                   <p>MetaReciclagem era uma rede descentralizada, mais ativa entre 2002 e 2012. Este site foi arquivado em 2016.</p>
+                  </div>
                   <div id="mission"><p>Apropria&ccedil;&atilde;o tecnol&oacute;gica para a transforma&ccedil;&atilde;o social</p></div>
 
 


### PR DESCRIPTION
Added a warning message block to index.html to indicate that MetaReciclagem is no longer active and the site was archived in 2016.
Used existing `messages warning` CSS classes for styling.

---
*PR created automatically by Jules for task [2308628900570685919](https://jules.google.com/task/2308628900570685919) started by @efeefe*